### PR TITLE
Update minio to explicitly specify console address

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -9,6 +9,7 @@ SKEY=$(cat /root/skey)
 
 # Enable the service
 sysrc -f /etc/rc.conf minio_enable="YES"
+sysrc -f /etc/rc.conf minio_console_address=":9001"
 sysrc -f /etc/rc.conf minio_env="MINIO_ACCESS_KEY=$AKEY MINIO_SECRET_KEY=$SKEY"
 
 # Setup backend directory

--- a/ui.json
+++ b/ui.json
@@ -1,3 +1,3 @@
 {
-	"adminportal": "http://%%IP%%:9000"
+	"adminportal": "http://%%IP%%:9001"
 }


### PR DESCRIPTION
This commit adds changes to explicitly specify minio console address as in the latest version(s), minio is now exposing 2 ports for different reasons. For UI we have console address and for minio server port, we have a separate port. If minio console address is not explicitly specified, it results in minio randomly choosing a port which it wants to use for minio console which results in inconsistent behavior as port forwarding gets broken with the new dynamic port not being mapped.